### PR TITLE
Fix for Check homework workflow

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,5 +1,5 @@
 name: Check homework
-on: [push]
+on: [push, workflow_dispatch]
 jobs:
   runner-job:
     runs-on: ubuntu-latest
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: set project_path
-        run: echo "PROJECTPATH=/home/runner/work/hw-backend-summer-2022-3-sql_querying/hw-backend-summer-2022-3-sql_querying" >> $GITHUB_ENV
+        run: echo "PROJECTPATH=/home/runner/work/${{ github.event.repository.name }}/${{ github.event.repository.name }}" >> $GITHUB_ENV
 
       - name: import db
         run:  export PGPASSWORD="$POSTGRES_PASSWORD"; psql --host="$POSTGRES_HOST" --port="$POSTGRES_PORT" --username="$POSTGRES_USER" --d="$POSTGRES_DATABASE" < "$PROJECTPATH/tests/data/demo.sql"


### PR DESCRIPTION
Add workflow_dispatch for manual action run (can be used to run workflow if actions were not included in the repositories (by default when importing the repository)).
Fixed PROJECTPATH for cases when the repository has a different name.

Добавлено workflow_dispatch для выполнения действий вручную (может использоваться для запуска сценария, если Actions не были включены в репозитории (по умолчанию при импорте репозитория)).
Исправлен PROJECTPATH для случаев, когда репозиторий имеет другое имя.